### PR TITLE
Issue 25: GitHub Actions CI/CDパイプラインの強化

### DIFF
--- a/.github/workflows/osc_bridge_tests.yml
+++ b/.github/workflows/osc_bridge_tests.yml
@@ -41,6 +41,12 @@ jobs:
             mkdir -p build && cd build
             cmake .. && make
           fi
+          
+          # ビルド成果物の確認
+          echo "::group::oscpack build verification"
+          find $GITHUB_WORKSPACE/oscpack -name "*.a" -o -name "*.lib" || echo "No libraries found"
+          ls -la $GITHUB_WORKSPACE/oscpack/build/ || echo "Build directory not found"
+          echo "::endgroup::"
       
       - name: Verify gitignore and protected files
         run: |
@@ -81,8 +87,20 @@ jobs:
         id: standalone_tests
         run: |
           echo "::group::Standalone Tests (Min-DevKit非依存)"
+          
+          # スクリプト実行前の診断情報
+          echo "環境変数の表示:"
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          
+          # 明示的にCMakeから直接ビルドを試行
+          cd $GITHUB_WORKSPACE/src/min-devkit/osc_bridge
+          cmake -S . -B build -DBUILD_OSC_BRIDGE_STANDALONE_TESTS=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+          cmake --build build
+          
+          # テスト実行
           chmod +x $GITHUB_WORKSPACE/run_tests.sh
           $GITHUB_WORKSPACE/run_tests.sh --standalone
+          
           echo "::endgroup::"
         continue-on-error: true
         
@@ -92,6 +110,22 @@ jobs:
           echo "従来のテスト: ${{ steps.legacy_tests.outcome == 'success' && '✅ 成功' || '❌ 失敗' }}"
           echo "スタンドアロンテスト: ${{ steps.standalone_tests.outcome == 'success' && '✅ 成功' || '❌ 失敗' }}"
           
+          # 詳細な診断情報（エラー時のトラブルシュート用）
+          if [[ "${{ steps.standalone_tests.outcome }}" != "success" ]]; then
+            echo "::group::スタンドアロンテスト詳細診断"
+            
+            echo "oscpackライブラリの検索:"
+            find $GITHUB_WORKSPACE -name "liboscpack.a" -o -name "oscpack.lib" || echo "No libraries found"
+            
+            echo "\nビルドディレクトリの内容:"
+            ls -la $GITHUB_WORKSPACE/src/min-devkit/osc_bridge/build/ || echo "Build directory listing failed"
+            
+            echo "\nテスト実行ファイルの検索:"
+            find $GITHUB_WORKSPACE/src/min-devkit/osc_bridge/build -name "test_osc_bridge_standalone" || echo "Test executable not found"
+            
+            echo "::endgroup::"
+          fi
+          
           # 少なくとも1つのテストセットが成功している場合は成功とする
           if [[ "${{ steps.legacy_tests.outcome }}" == "success" || "${{ steps.standalone_tests.outcome }}" == "success" ]]; then
             echo "少なくとも1つのテストセットが成功しました。"
@@ -99,6 +133,8 @@ jobs:
             echo "すべてのテストセットが失敗しました。"
             exit 1
           fi
+          
+          echo "::endgroup::"
           echo "::endgroup::"
       
       - name: Upload test results

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -19,7 +19,24 @@
 set -e
 
 # 設定
-PROJECT_ROOT="/Users/mymac/v8ui"
+# CI環境（GitHub Actions）では$GITHUB_WORKSPACEが利用可能
+# ローカル環境では自動検出またはデフォルト値を使用
+if [ -n "$GITHUB_WORKSPACE" ]; then
+    # GitHub Actions環境の場合
+    PROJECT_ROOT="$GITHUB_WORKSPACE"
+else 
+    # スクリプトパスから自動検出を試みる
+    SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)"
+    if [ -d "$SCRIPT_PATH/src/min-devkit/osc_bridge" ]; then
+        PROJECT_ROOT="$SCRIPT_PATH"
+    else
+        # 前方互換性のためのデフォルト値
+        PROJECT_ROOT="/Users/mymac/v8ui"
+        # 警告表示
+        echo "\033[33m警告: プロジェクトルートを自動検出できません。デフォルト値を使用します: $PROJECT_ROOT\033[0m"
+    fi
+fi
+
 BUILD_DIR="${PROJECT_ROOT}/src/min-devkit/osc_bridge/build"
 TEST_RESULTS_DIR="${PROJECT_ROOT}/docs/test_results"
 DATE_STAMP=$(date +"%Y%m%d_%H%M%S")

--- a/src/min-devkit/osc_bridge/tests/CMakeLists.txt
+++ b/src/min-devkit/osc_bridge/tests/CMakeLists.txt
@@ -11,8 +11,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # ルートディレクトリからの相対パス
 get_filename_component(ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
 
+# GitHub Actions環境のチェック
+if(DEFINED ENV{GITHUB_WORKSPACE})
+    set(GITHUB_ROOT_DIR "$ENV{GITHUB_WORKSPACE}")
+    message(STATUS "Running in GitHub Actions environment: ${GITHUB_ROOT_DIR}")
+    set(ROOT_DIR "${GITHUB_ROOT_DIR}")
+endif()
+
 # oscpackライブラリへのパス
 set(OSCPACK_ROOT_DIR "${ROOT_DIR}/oscpack")
+message(STATUS "Using OSCPACK_ROOT_DIR: ${OSCPACK_ROOT_DIR}")
 
 # oscpackのインクルードパス
 include_directories(
@@ -43,11 +51,11 @@ include_directories(
 set(TEST_SOURCES
     standalone_test.cpp
     error_recovery_test_new.cpp
-    # Issue 24で追加したテストファイル
-    # extended_types_test_new.cpp
-    # m4l_lifecycle_test_new.cpp
-    # multi_instance_test_new.cpp
-    # performance_test_new.cpp
+    # Issue 26で有効化したテストファイル
+    extended_types_test_new.cpp  # スタンドアロン対応に更新
+    m4l_lifecycle_test_new.cpp
+    multi_instance_test_new.cpp  # スタンドアロン対応に更新
+    performance_test_new.cpp     # スタンドアロン対応に更新
 )
 
 # メインのテスト実行ファイル
@@ -58,9 +66,20 @@ set(OSCPACK_LIB_CANDIDATES
     "${OSCPACK_ROOT_DIR}/build_universal/liboscpack.a"  # 優先度最高（ユニバーサルビルド）
     "${OSCPACK_ROOT_DIR}/build/liboscpack.a"
     "${OSCPACK_ROOT_DIR}/lib/liboscpack.a"
+    "${ROOT_DIR}/src/min-devkit/osc_bridge/../../../oscpack/build_universal/liboscpack.a" # 代替パス（GitHub Actions環境用）
+    "${ROOT_DIR}/oscpack/build/liboscpack.a"
     "${OSCPACK_ROOT_DIR}/build/oscpack.lib"
     "${OSCPACK_ROOT_DIR}/lib/oscpack.lib"
 )
+
+# 調査用: 存在するファイルのリスト表示
+foreach(CANDIDATE ${OSCPACK_LIB_CANDIDATES})
+    if(EXISTS "${CANDIDATE}")
+        message(STATUS "Found oscpack candidate: ${CANDIDATE}")
+    else()
+        message(STATUS "Missing oscpack candidate: ${CANDIDATE}")
+    endif()
+endforeach()
 
 # 実際のライブラリパスを探索
 foreach(CANDIDATE ${OSCPACK_LIB_CANDIDATES})
@@ -73,8 +92,27 @@ endforeach()
 # OSCpackライブラリとリンク
 if(DEFINED OSCPACK_LIB)
     message(STATUS "Using oscpack library: ${OSCPACK_LIB}")
-    target_link_libraries(test_osc_bridge_standalone PRIVATE "${OSCPACK_LIB}")
+    if(APPLE)
+        # macOS環境ではAファイルを直接リンク
+        target_link_libraries(test_osc_bridge_standalone PRIVATE "${OSCPACK_LIB}")
+    else()
+        # パスが設定されている場合は、ファイルの存在確認
+        target_link_libraries(test_osc_bridge_standalone PRIVATE "${OSCPACK_LIB}")
+        # ディレクトリをリンクパスに追加
+        get_filename_component(OSCPACK_LIB_DIR "${OSCPACK_LIB}" DIRECTORY)
+        target_link_directories(test_osc_bridge_standalone PRIVATE "${OSCPACK_LIB_DIR}")
+    endif()
 else()
+    # ディレクトリブラリ検索パスを追加
+    if(EXISTS "${OSCPACK_ROOT_DIR}/build")
+        message(STATUS "Adding oscpack build directory to link path: ${OSCPACK_ROOT_DIR}/build")
+        target_link_directories(test_osc_bridge_standalone PRIVATE "${OSCPACK_ROOT_DIR}/build")
+    endif()
+    if(EXISTS "${ROOT_DIR}/oscpack/build")
+        message(STATUS "Adding oscpack build directory to link path: ${ROOT_DIR}/oscpack/build")
+        target_link_directories(test_osc_bridge_standalone PRIVATE "${ROOT_DIR}/oscpack/build")
+    endif()
+    
     message(STATUS "Using generic oscpack library")
     target_link_libraries(test_osc_bridge_standalone PRIVATE "oscpack")
 endif()


### PR DESCRIPTION
このPRはOSC BridgeのCIパイプラインの強化を行うものです。\n\n## 変更内容\n1. run_tests.shの環境検出機能強化 - CI環境とローカル環境の両方に対応\n2. テストCMakeListsのoscpackライブラリパス検索改善\n3. GitHub Actionsワークフローの診断機能強化\n4. スタンドアロンテスト環境の互換性向上\n\n## テスト\n- ローカル環境: OSC Bridgeテスト全て成功\n- CI環境: 修正後のワークフロー実行で確認済み